### PR TITLE
Allow Defining Custom Flare config.xml File 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Uses code from [privacy.sexy](https://privacy.sexy) to disable Defender and Tamp
     # Disable the red/green dynamic Ludus wallpaper in favor of the static flarevm wallpaper
     ludus_flarevm_use_flarevm_wallpaper: true
 
+    # Specify custom config.xml file.  Defaults to config.xml provided by Mandiant.
+    ludus_flarevm_config_file: "https://raw.githubusercontent.com/mandiant/flare-vm/refs/heads/main/config.xml"
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 ludus_flarevm_use_flarevm_wallpaper: true
-ludus_flarevm_config_file: "https://github.com/mandiant/flare-vm/blob/main/config.xml"
+ludus_flarevm_config_file: "https://raw.githubusercontent.com/mandiant/flare-vm/refs/heads/main/config.xml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 ludus_flarevm_use_flarevm_wallpaper: true
+ludus_flarevm_config_file: "https://github.com/mandiant/flare-vm/blob/main/config.xml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,7 +144,7 @@
     ludus_download_file_host_path: "C:\\ludus\\flarevm"
 
 - name: Run the Flare installer script
-  ansible.windows.win_shell: ".\\install.ps1 -noPassword -noWait -noGui -noChecks"
+  ansible.windows.win_shell: ".\\install.ps1 -noPassword -noWait -noGui -noChecks -customConfig {{ ludus_flarevm_config_file }} "
   args:
     chdir: "C:\\ludus\\flarevm"
   async: 100


### PR DESCRIPTION
This pull request adds a role variable, `ludus_flarevm_config_file`, that can be used to define a custom configuration file for Flare deployments.  By default, the config.xml provided by Mandiant is used.